### PR TITLE
Allow conditional setting of analytics.load()

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ plugins: [
             // when process.env.NODE_ENV === 'development'
             // optional; non-empty string
             devKey: `SEGMENT_DEV_WRITE_KEY`,
+            // boolean (defaults to false) on whether you want
+            // to load all analytics automatically
+            // if true, window.analytics.load(writeKey) will need to be called in app
+            // used for halting cookies from analytics until a web visitor accepts cookies
+            loadOnRender: true,
 
             // boolean (defaults to false) on whether you want
             // to include analytics.page() automatically

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
-    const { trackPage, prodKey, devKey } = pluginOptions;
+    const { trackPage, prodKey, devKey, loadOnRender } = pluginOptions;
 
     // ensures Segment write key is present
     if (!prodKey || prodKey.length < 10)
@@ -15,14 +15,21 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     // note below, snippet wont render unless writeKey is truthy
     const writeKey = process.env.NODE_ENV === "production" ? prodKey : devKey;
 
+    // Stops initial loading of scripts, this lets you build functionality for cookie settings to comply with EU cookie law.
+    //  window.analytics.load() can then be called manually in app
+    const includeLoadOnRender = !loadOnRender ? "" : `analytics.load('${writeKey}');`;
+
     // if trackPage option is falsy (undefined or false), remove analytics.page(), else keep it in by default
-    const includeTrackPage = !trackPage ? "" : "analytics.page();";
+    const includeTrackPage = !trackPage || !loadOnRender ? "" : "analytics.page();";
 
     // Segment's minified snippet (version 4.1.0)
-    const snippet = `!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
-    analytics.load('${writeKey}');
+
+    let snippet = `!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
+    ${includeLoadOnRender}
+    ${includeTrackPage}
     }}();
   `;
+
 
     // only render snippet if write key exists
     if (writeKey) {


### PR DESCRIPTION
To comply with EU cookie law we wanted to halt the running of the analytics.load() until our users had accepted cookies. To do this we had to remove the analytics.load() from snippet and call it manually later in our app. This pull requests adds an additional setting to allow other folks to do this easily if they need to.