### PR TITLE
Add a delayed load function to improve TTI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ plugins: [
             // to include analytics.page() automatically
             // if false, see below on how to track pageviews manually
             trackPage: false
+
+            // boolean (defaults to false) on whether to load segment
+            // after a user action (scroll) + 1s delay
+            // this will bring down your TTI but you might miss 1 second of data.
+            delayLoad: false
         }
     }
 ];

--- a/README.md
+++ b/README.md
@@ -39,13 +39,16 @@ plugins: [
             // boolean (defaults to false) on whether you want
             // to include analytics.page() automatically
             // if false, see below on how to track pageviews manually
-            trackPage: false
+            trackPage: false,
 
             // boolean (defaults to false) on whether to load segment
-            // after a user action (scroll or route change) + 1s delay
+            // after a user action (scroll or route change) + delay
             // this will bring down your TTI but you might miss 1 second of data.
             // see here for more info on TTI: https://github.com/GoogleChrome/lighthouse/blob/master/docs/scoring.md#performance
-            delayLoad: false
+            delayLoad: false,
+
+            // time to wait after scroll action in ms. Defaults to 1000ms
+            delayLoadTime: 1000
         }
     }
 ];

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ plugins: [
             // boolean (defaults to false) on whether to load segment
             // after a user action (scroll or route change) + 1s delay
             // this will bring down your TTI but you might miss 1 second of data.
+            // see here for more info on TTI: https://github.com/GoogleChrome/lighthouse/blob/master/docs/scoring.md#performance
             delayLoad: false
         }
     }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ plugins: [
             trackPage: false
 
             // boolean (defaults to false) on whether to load segment
-            // after a user action (scroll) + 1s delay
+            // after a user action (scroll or route change) + 1s delay
             // this will bring down your TTI but you might miss 1 second of data.
             delayLoad: false
         }

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -5,6 +5,8 @@ exports.onRouteUpdate = ({ prevLocation }, { trackPage }) => {
     }
   }
 
+  // If this is a second page loaded via Gatsby routing, and the delayed loader has 
+  // not been loaded yet, we want to load it and then track the page.
   if (prevLocation && window.segmentSnippetLoaded === false) {
     window.segmentSnippetLoader(() => {
       trackSegmentPage();

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,5 +1,19 @@
-exports.onRouteUpdate = ({}, { trackPage }) => {
+exports.onRouteUpdate = ({ prevLocation }, { trackPage }) => {
+  function trackSegmentPage() {
     if (trackPage) {
-        window.analytics && window.analytics.page();
+      window.analytics && window.analytics.page();
     }
+  }
+
+  if (
+    prevLocation &&
+    window.segmentSnippetLoaded === false &&
+    wiindow.segmentSnippetLoading === false
+  ) {
+    window.segmentSnippetLoader(() => {
+      trackSegmentPage();
+    });
+  } else {
+    trackSegmentPage();
+  }
 };

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -5,11 +5,7 @@ exports.onRouteUpdate = ({ prevLocation }, { trackPage }) => {
     }
   }
 
-  if (
-    prevLocation &&
-    window.segmentSnippetLoaded === false &&
-    wiindow.segmentSnippetLoading === false
-  ) {
+  if (prevLocation && window.segmentSnippetLoaded === false) {
     window.segmentSnippetLoader(() => {
       trackSegmentPage();
     });

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -24,12 +24,23 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     }}();
   `;
 
-    const delayedLoader = `window.addEventListener('scroll',() =>
-      setTimeout(() => {
-        ${snippet}
-      }, 1000),
-    { once: true }
-    );`
+    const delayedLoader = `
+      window.segmentSnippetLoaded = false;
+      window.segmentSnippetLoading = false;
+
+      window.segmentSnippetLoader = (callback) => {
+        if (!window.segmentSnippetLoaded && !window.segmentSnippetLoading) {
+          window.segmentSnippetLoading = true;
+          setTimeout(() => {
+            ${snippet}
+            window.segmentSnippetLoading = false;
+            window.segmentSnippetLoaded = true;
+            if(callback) {callback()}
+          }, 1000);
+        }
+      }
+      window.addEventListener('scroll',() => {window.segmentSnippetLoader()}, { once: true });
+    `
 
     // if delayLoad option is true, use the delayed loader
     const snippetToUse = delayLoad ? delayedLoader : snippet;

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
-    const { trackPage, prodKey, devKey, delayLoad } = pluginOptions;
+    const { trackPage, prodKey, devKey, delayLoad, delayLoadTime } = pluginOptions;
 
     // ensures Segment write key is present
     if (!prodKey || prodKey.length < 10)
@@ -20,7 +20,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
 
     // Segment's minified snippet (version 4.1.0)
     const snippet = `!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
-    analytics.load('${writeKey}');
+    ${!delayLoad ? `analytics.load('${writeKey}');` : ``}
     }}();
   `;
 
@@ -28,22 +28,35 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
       window.segmentSnippetLoaded = false;
       window.segmentSnippetLoading = false;
 
-      window.segmentSnippetLoader = (callback) => {
+      window.segmentSnippetLoader = function (callback) {
         if (!window.segmentSnippetLoaded && !window.segmentSnippetLoading) {
           window.segmentSnippetLoading = true;
-          setTimeout(() => {
-            ${snippet}
+
+          function loader() {
+            window.analytics.load('${writeKey}');
             window.segmentSnippetLoading = false;
             window.segmentSnippetLoaded = true;
             if(callback) {callback()}
-          }, 1000);
+          };
+
+          setTimeout(
+            function () {
+              "requestIdleCallback" in window
+                ? requestIdleCallback(function () {loader()})
+                : loader();
+            },
+            ${delayLoadTime} || 1000
+          );
         }
       }
-      window.addEventListener('scroll',() => {window.segmentSnippetLoader()}, { once: true });
+      window.addEventListener('scroll',function () {window.segmentSnippetLoader()}, { once: true });
     `
 
     // if delayLoad option is true, use the delayed loader
-    const snippetToUse = delayLoad ? delayedLoader : snippet;
+    const snippetToUse = `
+      ${delayLoad ? delayedLoader : ''}
+      ${snippet}
+    `
 
     // only render snippet if write key exists
     if (writeKey) {

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
-    const { trackPage, prodKey, devKey } = pluginOptions;
+    const { trackPage, prodKey, devKey, delayLoad } = pluginOptions;
 
     // ensures Segment write key is present
     if (!prodKey || prodKey.length < 10)
@@ -24,12 +24,22 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     }}();
   `;
 
+    const delayedLoader = `window.addEventListener('scroll',() =>
+      setTimeout(() => {
+        ${snippet}
+      }, 1000),
+    { once: true }
+    );`
+
+    // if delayLoad option is true, use the delayed loader
+    const snippetToUse = delayLoad ? delayedLoader : snippet;
+
     // only render snippet if write key exists
     if (writeKey) {
         setHeadComponents([
             <script
                 key="plugin-segment"
-                dangerouslySetInnerHTML={{ __html: snippet }}
+                dangerouslySetInnerHTML={{ __html: snippetToUse }}
             />
         ]);
     }


### PR DESCRIPTION
The regular snippet will count towards your TTI, which can be harmful for your SEO rating especially if Segment loads a lot of scripts. I implemented a delayLoad option (defaults to false) that only loads the segment snippet if one of two conditions are met:

- The user has scrolled
- The user has navigated to another page (onRouteChange)

After which there is a 1s delay and the snippet is loaded. This follows the advice in this article: https://marketingexamples.com/seo/performance

You will lose at least the first second of any interaction which is why it should default to false.