### PR TITLE
Update links to Segment documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gatsby-plugin-segment-js
 
-A lightweight & feature-rich Gatsby plugin to easily add [Segment JS snippet](https://segment.com/docs/sources/website/analytics.js/quickstart/) to your site.
+A lightweight & feature-rich Gatsby plugin to easily add [Segment JS snippet](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/) to your site.
 
 ## Features
 
@@ -44,8 +44,8 @@ plugins: [
       // If you need to proxy events through a custom endpoint,
       // add a `host` property (defaults to https://cdn.segment.io)
       // Segment docs:
-      //   - https://segment.com/docs/guides/sources/custom-domains
-      //   - https://segment.com/docs/sources/website/analytics.js/#proxy
+      //   - https://segment.com/docs/connections/sources/custom-domains
+      //   - https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#proxy
       host: `https://override-segment-endpoint`,
 
       // boolean (defaults to false); whether to delay load Segment


### PR DESCRIPTION
Some of the redirects are not working properly, so I've replaced the old links with the (likely) new ones. 