### PR TITLE
add delay to page tracking call

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -8,11 +8,12 @@ exports.onRouteUpdate = ({ prevLocation }, { trackPage }) => {
   // This `if/then` logic relates to the `delayLoad` functionality to help prevent
   // calling `trackPage` twice. If you don't use that feature, you can ignore. Here
   // call `trackPage` only _after_ we change routes (on the client).
+  // Adding a 50ms delay ensure that the segment route tracking is in sync with the actual Gatsby route. Otherwise you can end up in a state where the Segment page tracking reports the previous page on route change.
   if (prevLocation && window.segmentSnippetLoaded === false) {
     window.segmentSnippetLoader(() => {
-      trackSegmentPage();
+      window.setTimeout(trackSegmentPage, 50)
     });
   } else {
-    trackSegmentPage();
+    window.setTimeout(trackSegmentPage, 50)
   }
 };


### PR DESCRIPTION
adding a delay to the tracking call gives the analytics.js page event and the gatsby router time to sync. i'm not sure where the actual break down is, but this seems to fix the page being one route change behind and the initial load event not firing
fixes #25, fixes #28, fixes #26 