### PR TITLE
send document.title with page events

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -5,7 +5,7 @@ exports.onRouteUpdate = ({ prevLocation }, { trackPage }) => {
     // page tracking reports the previous page on route change).
     window.setTimeout(() => {
       if (trackPage) {
-        window.analytics && window.analytics.page();
+        window.analytics && window.analytics.page(document.title);
       }
     }, 50);
   }


### PR DESCRIPTION
sending the page name in page calls is optional, but enriches data when present and is necessary for proper mapping to certain destinations. in my case `Page Title` in Google Analytics is blank if `name` is not included in the Segment page call.

i would be happy to make this a plugin option if you think that would be better

https://segment.com/docs/connections/spec/page/