### PR TITLE
add a `manualLoad` option that skips calling analytics.load

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ plugins: [
       // to include analytics.page() automatically
       // if false, see below on how to track pageviews manually
       trackPage: false,
-      
+
       // If you need to proxy events through a custom endpoint,
       // add a `host` property (defaults to https://cdn.segment.io)
       // Segment docs:
@@ -67,6 +67,13 @@ plugins: [
       // number (default to 1000); time to wait after scroll or route change
       // To be used when `delayLoad` is set to `true`
       delayLoadTime: 1000
+
+      // Whether to completely skip calling `analytics.load()`.
+      // ADVANCED FEATURE: only use if you are calling `analytics.load()` manually
+      // elsewhere in your code or are using a library
+      // like: https://github.com/segmentio/consent-manager that will call it for you.
+      // Useful for only loading the tracking script once a user has opted in to being tracked, for example.
+      manualLoad: false
     }
   }
 ];

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -8,6 +8,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     host = "https://cdn.segment.io",
     delayLoad,
     delayLoadTime,
+    manualLoad,
   } = pluginOptions;
 
   // ensures Segment write key is present
@@ -28,7 +29,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
 
   // Segment's minified snippet (version 4.1.0)
   const snippet = `!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="${host}/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
-  ${!delayLoad ? `analytics.load('${writeKey}');` : ``}
+  ${delayLoad || manualLoad ? `` : `analytics.load('${writeKey}');` }
   }}();`;
 
   const delayedLoader = `
@@ -61,7 +62,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
 
   // if `delayLoad` option is true, use the delayed loader
   const snippetToUse = `
-      ${delayLoad ? delayedLoader : ""}
+      ${delayLoad && !manualLoad ? delayedLoader : ""}
       ${snippet}
     `;
 


### PR DESCRIPTION
i need to wait to load analytics.js until a user accepts to be tracked on our site for GDPR, which i can't do currently. this adds an option that completely skips calling `analytics.load` from the plugin to allow manually calling it later.

i tested the different options(`{delayLoad: false, manualLoad: false}`, `{delayLoad: true, manualLoad: false}`, `{delayLoad: true, manualLoad: true}`, and `{delayLoad: false, manualLoad: true}` and everything seemed to be working as expected. this change gives precedence to `manualLoad`, so if `{delayLoad: true, manualLoad: true}` it won't load segment at all