### PR TITLE
Add delay option to page tracking call

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ plugins: [
       // if false, see below on how to track pageviews manually
       trackPage: false,
 
+      // number (defaults to 50); time to wait after a route update before it should
+      // track the page change
+      trackPageDelay: 300,
+
       // If you need to proxy events through a custom endpoint,
       // add a `host` property (defaults to https://cdn.segment.io)
       // Segment docs:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ plugins: [
 
       // number (defaults to 50); time to wait after a route update before it should
       // track the page change, to implement this, make sure your `trackPage` property is set to `true`
-      trackPageDelay: 300,
+      trackPageDelay: 50,
 
       // If you need to proxy events through a custom endpoint,
       // add a `host` property (defaults to https://cdn.segment.io)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ plugins: [
       trackPage: false,
 
       // number (defaults to 50); time to wait after a route update before it should
-      // track the page change
+      // track the page change, to implement this, make sure your `trackPage` property is set to `true`
       trackPageDelay: 300,
 
       // If you need to proxy events through a custom endpoint,

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,13 +1,16 @@
-exports.onRouteUpdate = ({ prevLocation }, { trackPage }) => {
+exports.onRouteUpdate = ({ prevLocation }, { trackPage, trackPageDelay = 50 }) => {
   function trackSegmentPage() {
-    // Adding a 50ms delay ensure that the segment route tracking is in sync with
-    // the actual Gatsby route (otherwise you can end up in a state where the Segment
-    // page tracking reports the previous page on route change).
+    // Adding a delay (defaults to 50ms when not provided by plugin option `trackPageDelay`)
+    // ensure that the segment route tracking is in sync with the actual Gatsby route
+    // (otherwise you can end up in a state where the Segment page tracking reports
+    // the previous page on route change).
+    const delay = Math.max(0, trackPageDelay)
+
     window.setTimeout(() => {
       if (trackPage) {
         window.analytics && window.analytics.page(document.title);
       }
-    }, 50);
+    }, delay);
   }
 
   // This `if/then` logic relates to the `delayLoad` functionality to help prevent


### PR DESCRIPTION
Hi there,

Following this [PR](https://github.com/benjaminhoffman/gatsby-plugin-segment-js/pull/30), I wanna have the ability to configure the delay applied to the page tracking call. Seems that sometimes, 50ms is not enough on my side so the tracking vs page update is not synced properly. I think it'd be better to let the user be able to set the delay that fits him the most than bumping it up.