### PR TITLE
fix: Set correct gatsby peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Easily add Segment JS snippet to your website",
   "version": "3.6.0",
   "main": "gatsby-ssr.js",
-  "repository": "git@github.com:benjaminhoffman/gatsby-plugin-segment.git",
+  "repository": "git@github.com:benjaminhoffman/gatsby-plugin-segment-js.git",
   "author": "benjamin hoffman <6520022+benjaminhoffman@users.noreply.github.com>",
   "license": "MIT",
   "keywords": [
@@ -26,5 +26,8 @@
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1"
+  },
+  "peerDependencies": {
+    "gatsby": "^3.0.0 || ^2.0.0"
   }
 }


### PR DESCRIPTION
Hello @TomPridham, Gatsby maintainer here 👋 
First and foremost, thanks for creating the plugin & maintaining it. Much appreciated!

While looking at your plugin I noticed that the `peerDependency` on `gatsby` is not set. We're in the process of providing more helpful information on the `/plugins` page of our website and for that we need plugins to set their `peerDependencies` correctly/more specific.

Making it more explicit is the safer choice (in the future you'll be able to mark breaking changes with explicit version ranges) and will allow us to display the plugin as compatible to versions X, Y, Z.

I also fixed the incorrect `repository` field :)

Thanks!