### PR TITLE
Address Gatsby v4 peerDependency warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-segment-js",
   "description": "Easily add Segment JS snippet to your website",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "main": "gatsby-ssr.js",
   "repository": "git@github.com:benjaminhoffman/gatsby-plugin-segment-js.git",
   "author": "benjamin hoffman <6520022+benjaminhoffman@users.noreply.github.com>",
@@ -31,6 +31,6 @@
     "eslint-plugin-react": "^7.24.0"
   },
   "peerDependencies": {
-    "gatsby": "^3.0.0 || ^2.0.0"
+    "gatsby": "^2 || ^3 || ^4"
   }
 }


### PR DESCRIPTION
The latest v3.7.0 currently displays:

```
warn Plugin gatsby-plugin-segment-js is not compatible with your gatsby version 4.1.0 - It requires gatsby@^3.0.0 || ^2.0.0
```

Inspired by https://github.com/mongkuen/gatsby-plugin-eslint/commit/67aad8e13415799404afa6048554deb66b0f48d3
Resolves #42.